### PR TITLE
Correct the location of 'shouldEndSession' in response json

### DIFF
--- a/alexandra/util.py
+++ b/alexandra/util.py
@@ -39,9 +39,9 @@ def respond(text=None, ssml=None, attributes=None, reprompt_text=None,
 
     obj = {
         'version': '1.0',
-        'shouldEndSession': end_session,
         'response': {
-            'outputSpeech': {'type': 'PlainText', 'text': ''}
+            'outputSpeech': {'type': 'PlainText', 'text': ''},
+            'shouldEndSession': end_session
         },
         'sessionAttributes': attributes or {}
     }

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -17,9 +17,9 @@ class TestRespond:
 
         assert resp == {
             'version': '1.0',
-            'shouldEndSession': True,
             'response': {
-                'outputSpeech': {'type': 'PlainText', 'text': ''}
+                'outputSpeech': {'type': 'PlainText', 'text': ''},
+                'shouldEndSession': True
             },
             'sessionAttributes': {}
         }
@@ -27,12 +27,14 @@ class TestRespond:
     def test_output_format(self):
         resp = util.respond(text='foobar')
         assert resp['response'] == {
-            'outputSpeech': {'type': 'PlainText', 'text': 'foobar'}
+            'outputSpeech': {'type': 'PlainText', 'text': 'foobar'},
+            'shouldEndSession': True
         }
 
         resp = util.respond(ssml='foobar')
         assert resp['response'] == {
-            'outputSpeech': {'type': 'SSML', 'ssml': 'foobar'}
+            'outputSpeech': {'type': 'SSML', 'ssml': 'foobar'},
+            'shouldEndSession': True
         }
 
     def test_reprompt(self):
@@ -52,9 +54,9 @@ class TestRespond:
 
         assert resp == {
             'version': '1.0',
-            'shouldEndSession': False,
             'response': {
                 'outputSpeech': {'type': 'PlainText', 'text': 'foo'},
+                'shouldEndSession': False,
                 'reprompt': {
                     'outputSpeech': {'type': 'SSML', 'ssml': 'bar'}
                 }


### PR DESCRIPTION
shouldEndSession is always seen by Alexa as True. The json response body has "shouldEndSession" incorrectly at the first level, but it should be an element of the "response" element, and at the same level as "output speech" and "reprompt". See https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interface-reference. 