### PR TITLE
Use `posixpath` instead of `os.path`

### DIFF
--- a/alexandra/util.py
+++ b/alexandra/util.py
@@ -2,7 +2,7 @@
 
 import base64
 import logging
-import os.path
+import posixpath
 
 try:
     from urlparse import urlparse
@@ -159,7 +159,7 @@ def _get_certificate(cert_url):
 
     url = urlparse(cert_url)
     host = url.netloc.lower()
-    path = os.path.normpath(url.path)
+    path = posixpath.normpath(url.path)
 
     # Sanity check location so we don't get some random person's cert.
     if url.scheme != 'https' or \

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -151,6 +151,7 @@ class TestValidateCertificate:
             'https://s3.amazonaws.com/EcHo.aPi/echo-api-cert.pem',
             'https://s3.amazonaws.com/invalid.path/echo-api-cert.pem',
             'https://s3.amazonaws.com:563/echo.api/echo-api-cert.pem',
+            'https://s3.amazonaws.com:443/echo.api/../echo-api-cert.pem',
         ]
 
         for case in cases:


### PR DESCRIPTION
We always want to use the posix behavior here, as `os.path.normpath`
unexpectedly converts `/` -> `\` on Windows.

See #11 for more context.